### PR TITLE
feat: add 3D Gaussian Splatting viewer tool

### DIFF
--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/website/app/components/SplatViewer.tsx
+++ b/website/app/components/SplatViewer.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { Canvas, useThree } from "@react-three/fiber";
+import {
+  GizmoHelper,
+  GizmoViewport,
+  Grid,
+  OrbitControls,
+} from "@react-three/drei";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import * as THREE from "three";
+import { SparkRenderer, SplatMesh } from "@sparkjsdev/spark";
+
+type FitFn = () => void;
+
+function SparkSceneSetup() {
+  const { gl, scene } = useThree();
+
+  useEffect(() => {
+    const spark = new SparkRenderer({ renderer: gl });
+    scene.add(spark);
+    return () => {
+      scene.remove(spark);
+    };
+  }, [gl, scene]);
+
+  return null;
+}
+
+type SplatProps = {
+  url: string;
+  onReady?: () => void;
+  onFitReady?: (fit: FitFn) => void;
+};
+
+function Splat({ url, onReady, onFitReady }: SplatProps) {
+  const { camera, controls } = useThree() as unknown as {
+    camera: THREE.PerspectiveCamera;
+    controls: { target: THREE.Vector3; update: () => void } | null;
+  };
+
+  const [mesh, setMesh] = useState<SplatMesh | null>(null);
+  const meshRef = useRef<SplatMesh | null>(null);
+
+  const fitToScene = useCallback(() => {
+    const m = meshRef.current;
+    if (!m) return;
+    if (!m.packedSplats && !m.extSplats) return;
+
+    m.position.set(0, 0, 0);
+    m.updateMatrixWorld(true);
+
+    const bbox = m.getBoundingBox(false);
+    const center = new THREE.Vector3();
+    const size = new THREE.Vector3();
+    bbox.getCenter(center);
+    bbox.getSize(size);
+
+    // eslint-disable-next-line no-console
+    console.log("[SplatViewer] bbox", {
+      center: center.toArray(),
+      size: size.toArray(),
+      length: size.length(),
+    });
+
+    m.position.sub(center);
+
+    const radius = Math.max(0.1, size.length() * 0.5);
+    const distance =
+      (radius / Math.sin((camera.fov * Math.PI) / 360)) * 1.3;
+
+    const dir = new THREE.Vector3(1, 0.7, 1).normalize();
+    camera.position.copy(dir).multiplyScalar(distance);
+    camera.near = Math.max(0.001, distance / 1000);
+    camera.far = Math.max(distance * 100, 1000);
+    camera.lookAt(0, 0, 0);
+    camera.updateProjectionMatrix();
+
+    if (controls?.target) {
+      controls.target.set(0, 0, 0);
+      controls.update?.();
+    }
+  }, [camera, controls]);
+
+  useEffect(() => {
+    onFitReady?.(fitToScene);
+  }, [fitToScene, onFitReady]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const m = new SplatMesh({ url });
+    setMesh(m);
+    m.initialized
+      .then((loaded) => {
+        if (cancelled) return;
+        if (!loaded.packedSplats && !loaded.extSplats) return;
+        meshRef.current = loaded;
+        fitToScene();
+        onReady?.();
+      })
+      .catch((err) => {
+        console.error("[SplatViewer] failed to load:", err);
+      });
+
+    return () => {
+      cancelled = true;
+      meshRef.current = null;
+      m.dispose();
+    };
+  }, [url, fitToScene, onReady]);
+
+  if (!mesh) return null;
+  return <primitive object={mesh as unknown as THREE.Object3D} />;
+}
+
+type SplatViewerProps = {
+  url: string;
+};
+
+export default function SplatViewer({ url }: SplatViewerProps) {
+  const [ready, setReady] = useState(false);
+  const onReady = useRef(() => setReady(true)).current;
+  const fitRef = useRef<FitFn | null>(null);
+
+  useEffect(() => {
+    setReady(false);
+  }, [url]);
+
+  const onFitReady = useCallback((fit: FitFn) => {
+    fitRef.current = fit;
+  }, []);
+
+  return (
+    <div className="relative w-full h-full">
+      <Canvas
+        camera={{ position: [0, 0, 3], fov: 60, near: 0.01, far: 1000 }}
+        gl={{ antialias: false, premultipliedAlpha: true }}
+        style={{ background: "#0a0a0a" }}
+      >
+        <SparkSceneSetup />
+        <Suspense fallback={null}>
+          <Splat url={url} onReady={onReady} onFitReady={onFitReady} />
+        </Suspense>
+        <axesHelper args={[1]} />
+        <Grid
+          args={[20, 20]}
+          cellColor="#3a3a3a"
+          sectionColor="#606060"
+          sectionSize={5}
+          fadeDistance={30}
+          fadeStrength={1}
+          infiniteGrid
+        />
+        <OrbitControls enableDamping makeDefault />
+        <GizmoHelper alignment="top-right" margin={[64, 64]}>
+          <GizmoViewport
+            axisColors={["#e53e3e", "#38a169", "#3182ce"]}
+            labelColor="white"
+          />
+        </GizmoHelper>
+      </Canvas>
+      <button
+        onClick={() => fitRef.current?.()}
+        className="absolute bottom-3 right-3 z-10 bg-black/60 hover:bg-black/80 backdrop-blur text-white text-sm rounded px-3 py-1.5 transition-colors"
+        title="Re-fit camera to the splat"
+      >
+        Fit to scene
+      </button>
+      {!ready && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-white/80 text-sm">
+          Decoding splat…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/app/tools/3dgs-viewer/page.tsx
+++ b/website/app/tools/3dgs-viewer/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+
+const SplatViewer = dynamic(() => import("@/app/components/SplatViewer"), {
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm bg-black">
+      Loading viewer…
+    </div>
+  ),
+});
+
+const ACCEPTED_EXTENSIONS = [".ply", ".spz", ".splat", ".ksplat"];
+
+export default function SplatViewerPage() {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    return () => {
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+  }, [blobUrl]);
+
+  const acceptFile = useCallback(
+    (file: File | undefined) => {
+      if (!file) return;
+      const lowerName = file.name.toLowerCase();
+      const ok = ACCEPTED_EXTENSIONS.some((ext) => lowerName.endsWith(ext));
+      if (!ok) {
+        setError(
+          `Unsupported file type. Expected one of: ${ACCEPTED_EXTENSIONS.join(", ")}`
+        );
+        return;
+      }
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+      setError(null);
+      setFileName(file.name);
+      setBlobUrl(URL.createObjectURL(file));
+    },
+    [blobUrl]
+  );
+
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setIsDragging(false);
+      acceptFile(e.dataTransfer.files?.[0]);
+    },
+    [acceptFile]
+  );
+
+  const reset = useCallback(() => {
+    if (blobUrl) URL.revokeObjectURL(blobUrl);
+    setBlobUrl(null);
+    setFileName(null);
+    setError(null);
+    if (inputRef.current) inputRef.current.value = "";
+  }, [blobUrl]);
+
+  return (
+    <div
+      className={`bg-white flex flex-col ${blobUrl ? "" : "min-h-screen"}`}
+      style={
+        blobUrl
+          ? { height: "calc(100vh - 80px)" } // leave room for the site header
+          : undefined
+      }
+    >
+      {/* Breadcrumb strip */}
+      <div className="border-b border-gray-100 bg-white">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between gap-4">
+          <nav className="text-sm">
+            <ol className="flex items-center space-x-2 text-gray-500">
+              <li>
+                <Link href="/" className="hover:text-green-600">
+                  Home
+                </Link>
+              </li>
+              <li>/</li>
+              <li>
+                <Link href="/tools" className="hover:text-green-600">
+                  Tools
+                </Link>
+              </li>
+              <li>/</li>
+              <li className="text-gray-900 font-medium">
+                3D Gaussian Splatting Viewer
+              </li>
+            </ol>
+          </nav>
+          <div className="w-24" />
+        </div>
+      </div>
+
+      {/* Main area */}
+      {!blobUrl ? (
+        <div className="flex-1 max-w-6xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-6 flex flex-col">
+          <div
+            onDragOver={(e) => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={onDrop}
+            onClick={() => inputRef.current?.click()}
+            className={`flex-1 min-h-[60vh] rounded-xl border-2 border-dashed flex flex-col items-center justify-center text-center cursor-pointer transition-colors p-8 ${
+              isDragging
+                ? "border-green-500 bg-green-50"
+                : "border-gray-300 bg-gray-50 hover:border-green-400 hover:bg-gray-100"
+            }`}
+          >
+            <svg
+              className="h-10 w-10 text-gray-400 mb-3"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 7.5 7.5 12M12 7.5V21"
+              />
+            </svg>
+            <p className="text-gray-700 font-medium mb-1">
+              Drop a .ply file here, or click to choose
+            </p>
+            <p className="text-sm text-gray-500">
+              Supported: {ACCEPTED_EXTENSIONS.join(", ")}. Everything runs in
+              your browser — nothing is uploaded.
+            </p>
+            <input
+              ref={inputRef}
+              type="file"
+              accept={ACCEPTED_EXTENSIONS.join(",")}
+              className="hidden"
+              onChange={(e) => acceptFile(e.target.files?.[0])}
+            />
+            {error && (
+              <p className="mt-4 text-sm text-red-600">{error}</p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="relative flex-1 w-full bg-black">
+          {/* File info (top-left) */}
+          <div className="absolute top-3 left-3 z-10 bg-black/60 backdrop-blur text-white text-sm rounded px-3 py-1.5 truncate max-w-[55%]">
+            {fileName}
+          </div>
+          {/* Load-another (top-right) */}
+          <button
+            onClick={reset}
+            className="absolute top-3 right-3 z-10 bg-black/60 hover:bg-black/80 backdrop-blur text-white text-sm rounded px-3 py-1.5 transition-colors"
+          >
+            Load another file
+          </button>
+          {/* Help hint (bottom-left) */}
+          <div className="absolute bottom-3 left-3 z-10 text-white/60 text-xs">
+            Drag to orbit · scroll to zoom · right-click-drag to pan
+          </div>
+          <SplatViewer url={blobUrl} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/app/tools/page.tsx
+++ b/website/app/tools/page.tsx
@@ -22,6 +22,27 @@ const tools = [
       </svg>
     ),
   },
+  {
+    name: "3D Gaussian Splatting Viewer",
+    description:
+      "Upload a trained Gaussian Splatting .ply (e.g. from Nerfstudio's splatfacto) and render it in-browser with WebGL2. Supports .ply, .spz, .splat, and .ksplat.",
+    href: "/tools/3dgs-viewer",
+    icon: (
+      <svg
+        className="h-8 w-8 text-green-600"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 21a9 9 0 100-18 9 9 0 000 18zm0 0c-2.5 0-4-3-4-9s1.5-9 4-9m0 18c2.5 0 4-3 4-9s-1.5-9-4-9m-9 9h18"
+        />
+      </svg>
+    ),
+  },
 ];
 
 export default function ToolsPage() {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,6 +13,7 @@
         "@next/mdx": "^16.2.1",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.0",
+        "@sparkjsdev/spark": "^2.0.0",
         "gray-matter": "^4.0.3",
         "next": "16.2.1",
         "react": "19.2.4",
@@ -1461,6 +1462,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sparkjsdev/spark": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-2.0.0.tgz",
+      "integrity": "sha512-W1p7NM4xXcUAVVcVus2mIFwcAC3VckyE0l4wXJuSmhcOgb6hHpqhQ/Ks9MK9ts7j23K+UwbCBwe+aTc/zgGygw==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      },
+      "peerDependencies": {
+        "three": "^0.180.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1852,6 +1865,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3192,6 +3206,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "@next/mdx": "^16.2.1",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.0",
+    "@sparkjsdev/spark": "^2.0.0",
     "gray-matter": "^4.0.3",
     "next": "16.2.1",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary
- Adds a new `/tools/3dgs-viewer` page that accepts `.ply` / `.spz` / `.splat` / `.ksplat` files and renders them in-browser via `@sparkjsdev/spark` 2.0 on top of `@react-three/fiber`.
- Drag-and-drop or click-to-upload; once a file is loaded the canvas fills the full viewport (SuperSplat-style).
- Camera auto-fits to the splat's bounding box on load and re-centers the splat at world origin so the helpers sit inside the scene. A "Fit to scene" button re-runs the fit when needed (e.g. after free orbit).
- RGB axes at origin, infinite ground grid, and a clickable orientation gizmo (top-right) that snaps the camera to the clicked axis face.
- Adds a card for the new tool on the `/tools` landing page next to the existing Point Cloud Viewer.

## Implementation notes
- `SparkRenderer` is mounted into the R3F scene (Spark 2.0 requires it to supply shared render uniforms such as `renderSize`, `maxStdDev`, and the ordering texture — 0.1.10 didn't).
- `SplatMesh` is created inside the effect (not `useMemo`) so React 19 Strict Mode's double-invoke doesn't leave a disposed mesh behind; the bbox call is also guarded against `!packedSplats && !extSplats` for the same reason.
- `@sparkjsdev/spark@^2.0.0` installed with `--legacy-peer-deps` because its peer-deps pin `three ^0.180` and this repo uses `three@^0.183`. Tested working end-to-end on 3k- and 30k-step splatfacto exports; `next build` (Turbopack) passes.

## Test plan
- [ ] `npm run dev`, open `/opensource/tools/3dgs-viewer`
- [ ] Drop a trained `.ply` from `ns-export gaussian-splat` — splat renders, camera frames the scene, gizmo responds
- [ ] Orbit away, click "Fit to scene" — camera returns to a framed view
- [ ] "Load another file" button resets the viewer
- [ ] `npm run build` succeeds; `/tools/3dgs-viewer` is prerendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)