### PR TITLE
fix: 3DGS viewer auto-framing and add transform panel

### DIFF
--- a/website/app/components/SplatViewer.tsx
+++ b/website/app/components/SplatViewer.tsx
@@ -33,13 +33,67 @@ function SparkSceneSetup() {
   return null;
 }
 
+type Vec3 = { x: number; y: number; z: number };
+
+function TransformGroup({
+  title,
+  values,
+  onChange,
+  min,
+  max,
+  step,
+}: {
+  title: string;
+  values: Vec3;
+  onChange: (updater: (prev: Vec3) => Vec3) => void;
+  min: number;
+  max: number;
+  step: number;
+}) {
+  return (
+    <div>
+      <div className="font-semibold mb-2 text-xs uppercase tracking-wider text-white/70">
+        {title}
+      </div>
+      {(["x", "y", "z"] as const).map((axis) => (
+        <div key={axis} className="flex items-center gap-3 mb-2 last:mb-0">
+          <label className="w-4 font-mono uppercase">{axis}</label>
+          <input
+            type="range"
+            min={min}
+            max={max}
+            step={step}
+            value={values[axis]}
+            onChange={(e) =>
+              onChange((v) => ({ ...v, [axis]: Number(e.target.value) }))
+            }
+            className="flex-1 accent-green-500"
+          />
+          <input
+            type="number"
+            step={step}
+            value={values[axis]}
+            onChange={(e) =>
+              onChange((v) => ({ ...v, [axis]: Number(e.target.value) }))
+            }
+            className="w-16 bg-white/10 rounded px-2 py-1 text-right tabular-nums"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 type SplatProps = {
   url: string;
+  rotationDeg: Vec3;
+  positionOffset: Vec3;
+  scale: number;
   onReady?: () => void;
   onFitReady?: (fit: FitFn) => void;
 };
 
-function Splat({ url, onReady, onFitReady }: SplatProps) {
+function Splat({ url, rotationDeg, positionOffset, scale, onReady, onFitReady }: SplatProps) {
   const { camera, controls } = useThree() as unknown as {
     camera: THREE.PerspectiveCamera;
     controls: { target: THREE.Vector3; update: () => void } | null;
@@ -47,6 +101,7 @@ function Splat({ url, onReady, onFitReady }: SplatProps) {
 
   const [mesh, setMesh] = useState<SplatMesh | null>(null);
   const meshRef = useRef<SplatMesh | null>(null);
+  const groupRef = useRef<THREE.Group>(null);
 
   const fitToScene = useCallback(() => {
     const m = meshRef.current;
@@ -56,24 +111,50 @@ function Splat({ url, onReady, onFitReady }: SplatProps) {
     m.position.set(0, 0, 0);
     m.updateMatrixWorld(true);
 
-    const bbox = m.getBoundingBox(false);
-    const center = new THREE.Vector3();
-    const size = new THREE.Vector3();
-    bbox.getCenter(center);
-    bbox.getSize(size);
+    // Robust fit: use median center + percentile-based radius (distance from
+    // median). Spark's getBoundingBox and plain min/max are thrown off by a
+    // handful of outlier splats far from the main cluster, making the camera
+    // sit very far back and the real scene look like a tiny dot.
+    const xs: number[] = [];
+    const ys: number[] = [];
+    const zs: number[] = [];
+    m.forEachSplat((_i, c) => {
+      xs.push(c.x);
+      ys.push(c.y);
+      zs.push(c.z);
+    });
+    const n = xs.length;
+    if (n === 0) return;
+
+    const median = (arr: number[]) => {
+      const s = [...arr].sort((a, b) => a - b);
+      const mid = Math.floor(s.length / 2);
+      return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+    };
+    const center = new THREE.Vector3(median(xs), median(ys), median(zs));
+    if (!isFinite(center.x)) return;
+
+    const dists: number[] = new Array(n);
+    for (let i = 0; i < n; i++) {
+      const dx = xs[i] - center.x;
+      const dy = ys[i] - center.y;
+      const dz = zs[i] - center.z;
+      dists[i] = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+    dists.sort((a, b) => a - b);
+    // 90th percentile distance-from-median → ignores ~10% outliers.
+    const radius = Math.max(0.05, dists[Math.floor(n * 0.9)]);
 
     // eslint-disable-next-line no-console
-    console.log("[SplatViewer] bbox", {
+    console.log("[SplatViewer] fit", {
+      numSplats: n,
       center: center.toArray(),
-      size: size.toArray(),
-      length: size.length(),
+      radius,
     });
 
     m.position.sub(center);
 
-    const radius = Math.max(0.1, size.length() * 0.5);
-    const distance =
-      (radius / Math.sin((camera.fov * Math.PI) / 360)) * 1.3;
+    const distance = (radius / Math.tan((camera.fov * Math.PI) / 360)) * 0.2;
 
     const dir = new THREE.Vector3(1, 0.7, 1).normalize();
     camera.position.copy(dir).multiplyScalar(distance);
@@ -91,6 +172,18 @@ function Splat({ url, onReady, onFitReady }: SplatProps) {
   useEffect(() => {
     onFitReady?.(fitToScene);
   }, [fitToScene, onFitReady]);
+
+  useEffect(() => {
+    const g = groupRef.current;
+    if (!g) return;
+    g.position.set(positionOffset.x, positionOffset.y, positionOffset.z);
+    g.rotation.set(
+      (rotationDeg.x * Math.PI) / 180,
+      (rotationDeg.y * Math.PI) / 180,
+      (rotationDeg.z * Math.PI) / 180
+    );
+    g.scale.setScalar(scale);
+  }, [rotationDeg, positionOffset, scale, mesh]);
 
   useEffect(() => {
     let cancelled = false;
@@ -116,7 +209,11 @@ function Splat({ url, onReady, onFitReady }: SplatProps) {
   }, [url, fitToScene, onReady]);
 
   if (!mesh) return null;
-  return <primitive object={mesh as unknown as THREE.Object3D} />;
+  return (
+    <group ref={groupRef}>
+      <primitive object={mesh as unknown as THREE.Object3D} />
+    </group>
+  );
 }
 
 type SplatViewerProps = {
@@ -127,9 +224,15 @@ export default function SplatViewer({ url }: SplatViewerProps) {
   const [ready, setReady] = useState(false);
   const onReady = useRef(() => setReady(true)).current;
   const fitRef = useRef<FitFn | null>(null);
+  const [rotationDeg, setRotationDeg] = useState<Vec3>({ x: 0, y: 0, z: 0 });
+  const [positionOffset, setPositionOffset] = useState<Vec3>({ x: 0, y: 0, z: 0 });
+  const [scale, setScale] = useState(1);
 
   useEffect(() => {
     setReady(false);
+    setRotationDeg({ x: 0, y: 0, z: 0 });
+    setPositionOffset({ x: 0, y: 0, z: 0 });
+    setScale(1);
   }, [url]);
 
   const onFitReady = useCallback((fit: FitFn) => {
@@ -145,7 +248,14 @@ export default function SplatViewer({ url }: SplatViewerProps) {
       >
         <SparkSceneSetup />
         <Suspense fallback={null}>
-          <Splat url={url} onReady={onReady} onFitReady={onFitReady} />
+          <Splat
+            url={url}
+            rotationDeg={rotationDeg}
+            positionOffset={positionOffset}
+            scale={scale}
+            onReady={onReady}
+            onFitReady={onFitReady}
+          />
         </Suspense>
         <axesHelper args={[1]} />
         <Grid
@@ -172,6 +282,58 @@ export default function SplatViewer({ url }: SplatViewerProps) {
       >
         Fit to scene
       </button>
+      <div className="absolute top-16 left-3 z-10 bg-black/70 backdrop-blur text-white rounded-lg px-5 py-4 text-sm w-80 shadow-lg space-y-4">
+        <TransformGroup
+          title="Position"
+          values={positionOffset}
+          onChange={setPositionOffset}
+          min={-5}
+          max={5}
+          step={0.05}
+        />
+        <TransformGroup
+          title="Rotation (deg)"
+          values={rotationDeg}
+          onChange={setRotationDeg}
+          min={-180}
+          max={180}
+          step={1}
+        />
+        <div>
+          <div className="font-semibold mb-2 text-xs uppercase tracking-wider text-white/70">
+            Scale
+          </div>
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={0.1}
+              max={5}
+              step={0.01}
+              value={scale}
+              onChange={(e) => setScale(Number(e.target.value))}
+              className="flex-1 accent-green-500"
+            />
+            <input
+              type="number"
+              min={0.01}
+              step={0.05}
+              value={scale}
+              onChange={(e) => setScale(Number(e.target.value))}
+              className="w-16 bg-white/10 rounded px-2 py-1 text-right tabular-nums"
+            />
+          </div>
+        </div>
+        <button
+          onClick={() => {
+            setPositionOffset({ x: 0, y: 0, z: 0 });
+            setRotationDeg({ x: 0, y: 0, z: 0 });
+            setScale(1);
+          }}
+          className="w-full text-xs text-white/70 hover:text-white underline underline-offset-2"
+        >
+          Reset all
+        </button>
+      </div>
       {!ready && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-white/80 text-sm">
           Decoding splat…


### PR DESCRIPTION
## Summary
- Replace Spark's min/max bounding box with a robust median-center + 90th-percentile-radius fit. A handful of outlier splats were inflating the bbox and pushing the camera ~26 units away from the real ~1 unit cluster, making `splat7.ply` render as a tiny starburst instead of the scene. Ref: PathOn-AI/opensource_record3d#33.
- Add a Position / Rotation / Scale transform panel (sliders + number inputs) wired through a parent `THREE.Group`, so user transforms compose cleanly with auto-fit centering and reset on file change.
- Tighter distance factor (`tan(fov/2) × 0.2`) for closer initial framing.

## Test plan
- [ ] Drop `splat7.ply` into `/opensource/tools/3dgs-viewer` locally, verify scene is framed (not a starburst).
- [ ] Try Rotation sliders (X/Y/Z) — mesh should rotate live in the viewport.
- [ ] Try Position and Scale sliders — mesh should translate and scale live.
- [ ] Click "Reset all" — all transforms return to defaults.
- [ ] Click "Fit to scene" — camera re-centers on current transform.
- [ ] Load a different `.ply` — transform panel resets to zeros / scale 1.
- [ ] `npm run build` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)