### PR TITLE
feat(robot-assets-skills): add skill bundle for arm + end-effector workflows

### DIFF
--- a/robot-assets-skills/.claude/skills/attach-end-effector/SKILL.md
+++ b/robot-assets-skills/.claude/skills/attach-end-effector/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: attach-end-effector
+description: Mount an end-effector (parallel-jaw gripper, dexterous hand, suction tool, etc.) on a robot arm by attaching its MJCF to the arm's `attachment_site` via MuJoCo's MjSpec API. Use when combining an arm MJCF and an end-effector MJCF into a single combined model (e.g. piper_arm + barrett -> piper_arm_barrett). Handles known gotchas the underlying script doesn't: same-named mesh files silently overwriting each other, end-effectors whose root body origin sits on the wrong face for wrist mounting, empty-prefix failures (entity-name collisions and bare nested `<default>` blocks), and the script silently skipping gripper meshes when the gripper's `<compiler meshdir>` isn't `assets/`.
+---
+
+# attach-end-effector
+
+Wrap `attach_arm_gripper.py` (despite the file name, it works for any
+end-effector — gripper, dex hand, suction, sensor mount). The script
+loads two MJCFs as `MjSpec`, attaches the end-effector at the arm's
+`<site name="attachment_site"/>` with a name prefix, compiles, and
+writes a combined `<output>.xml` + `<output>.mjb` + `scene.xml` +
+`README.md` under `robots/<output>/`.
+
+The script gets the kinematic attach right but does **not** handle:
+
+1. Mesh-filename collisions between arm and end-effector mesh dirs
+   (e.g. piper and allegro both ship `base_link.stl` — the second copy
+   is silently dropped, mesh refs resolve to the wrong geometry).
+2. End-effectors whose root body's origin is on the wrong face of the
+   palm for wrist mounting (menagerie hands place the origin at the
+   front face, so the body extends *into* the arm under identity quat).
+3. Empty-prefix failures: entity-name collisions (`repeated name 'X'`)
+   AND bare nested `<default>` blocks in the eef source (`empty class
+   name`). Internal namespacing only protects against the first.
+4. End-effectors whose `<compiler meshdir>` isn't `assets/` — the
+   script hard-codes the gripper mesh source, silently copies zero
+   meshes, and emits no warning. Compile fails on missing mesh files.
+
+These are addressed in `references/gotchas.md` and the post-script
+checklist in `references/workflow.md`.
+
+## When to use this skill
+
+- Combining any arm + end-effector pair where both ship a standalone
+  MJCF and the arm exposes `<site name="attachment_site"/>` at its
+  wrist flange.
+- The output goes into `robots/<arm>_<eef>/` as a combined model
+  consumed by `mjcf_file:` in `robot.json`.
+
+## When NOT to use this skill
+
+- The arm has no `attachment_site` site (add one first, in arm-only).
+- You want a URDF combined model (this skill is MJCF-only).
+- You want to attach two arms (no `attachment_site` convention there).
+
+## Workflow
+
+1. Verify the arm MJCF has `<site name="attachment_site" .../>` on the
+   wrist link. If not, add it first in the arm-only file.
+2. **Choose a prefix.** Default to a non-empty prefix
+   (e.g. `barrett_`, `right_`). Empty prefix has two failure modes —
+   entity-name collisions AND bare nested `<default>` blocks — and
+   internal namespacing (e.g. barrett's `bh_*`) only protects against
+   the first. See `references/gotchas.md` §3 for the two `grep` checks
+   that justify empty if you really want it.
+3. Run the script (see Commands).
+4. **Verify gripper meshes were actually copied.** The script
+   hard-codes `<eef>/assets/` as the source; if the gripper's
+   `<compiler meshdir>` is anything else (e.g. barrett uses `meshes`),
+   zero gripper meshes get copied and the script emits no warning.
+   See `references/gotchas.md` §4 for the parse-meshdir + `cp` recipe.
+5. **Check for mesh-filename collisions in the merged `assets/`.** See
+   `references/gotchas.md` §1 (silent failure mode that bit us with
+   allegro_right + piper — both ship `base_link.stl`).
+6. **Check the end-effector mounts flush at the flange.** Open the
+   combined `scene.xml` in MuJoCo viewer. If the eef body extends
+   *into* the arm, set `pos="0 0 H"` on the prefixed root body so its
+   back face sits at the wrist; see `references/gotchas.md` §2.
+7. Verify all combined actuators map to the intended joints (sliders
+   in viewer should move the right things on both arm and eef).
+8. Drop a `robot.json` for the combined folder (mjcf-only registration,
+   `urdf_file: null`, `meshes_dir: assets`).
+
+## Commands
+
+Run from the bundle root with the bundle-local venv. The wrapped
+script lives in the parent repo at `../attach_arm_gripper.py`.
+`attach_arm_gripper.py` resolves relative `--arm` / `--gripper` /
+`--output` paths against *its own* directory (the parent repo), not
+the bundle's `robots/` — so pass **absolute** paths via `$(pwd)/`.
+
+```bash
+cd robot-assets-skills/
+./.venv/bin/python ../attach_arm_gripper.py \
+    --arm     "$(pwd)/robots/<arm>/<arm>.xml" \
+    --gripper "$(pwd)/robots/<eef>/<eef>.xml" \
+    --output  "$(pwd)/robots/<arm>_<eef>" \
+    --prefix  "<prefix>_" \
+    --no-viewer
+```
+
+Verify the model compiles and loads:
+
+```bash
+./.venv/bin/python -c "
+import mujoco
+m = mujoco.MjModel.from_xml_path('robots/<arm>_<eef>/<arm>_<eef>.xml')
+print('nq=', m.nq, 'nu=', m.nu, 'nbody=', m.nbody)
+"
+```
+
+View interactively (`DISPLAY=:5` on our headless box):
+
+```bash
+DISPLAY=:5 ./.venv/bin/python -m mujoco.viewer \
+    --mjcf robots/<arm>_<eef>/scene.xml
+```
+
+If `.venv/` doesn't exist or is missing packages, bootstrap per
+`AGENTS.md`'s "Python environment" section. If `robots/` is empty,
+bootstrap per `README.md`'s "First-time setup" (copy your arm + eef
+folders in).
+
+## References
+
+- Step-by-step procedure: `references/workflow.md`
+- Known gotchas with concrete fixes: `references/gotchas.md`

--- a/robot-assets-skills/.claude/skills/attach-end-effector/references/gotchas.md
+++ b/robot-assets-skills/.claude/skills/attach-end-effector/references/gotchas.md
@@ -1,0 +1,234 @@
+# `attach-end-effector` Gotchas
+
+Concrete failure modes the underlying `attach_arm_gripper.py` doesn't
+handle, with the fix recipe for each. Read this before declaring an
+attach "done".
+
+---
+
+## 1. Mesh-filename collisions silently render the wrong geometry
+
+**Symptom.** End-effector visual looks completely wrong (wrong shape,
+wrong size, often a "huge mystery box" hovering near the wrist). Model
+compiles cleanly; `nq`/`nu` are as expected.
+
+**Cause.** The script copies arm assets first, then end-effector
+assets, with `if not dest_file.exists(): copy`. If both arm and
+end-effector ship a STL/OBJ file with the **same filename**, the
+end-effector's version is *silently dropped* and its `<mesh file=...>`
+ref ends up resolving to the arm's mesh.
+
+**Concrete example we hit.** Piper arm's `base_link.stl` (535 KB,
+arm-base mesh) and allegro_right's `base_link.stl` (164 KB, palm mesh).
+The combined model's `<mesh name="right_base_link" file="base_link.stl"/>`
+silently rendered the piper arm-base as the allegro palm.
+
+**Detection.** After running the script, list `assets/` files and
+compare sizes:
+
+```bash
+diff <(stat -c '%n %s' robots/<arm>/assets/*) \
+     <(stat -c '%n %s' robots/<arm>_<eef>/assets/*)
+```
+
+Any size mismatch on a same-named file is the bug.
+
+**Fix.**
+
+1. Copy the end-effector's version with a prefixed name into the
+   combined `assets/`:
+   ```bash
+   cp robots/<eef>/assets/base_link.stl \
+      robots/<arm>_<eef>/assets/<prefix>_base_link.stl
+   ```
+2. Update the combined XML's `<mesh file=...>` ref to point at the
+   renamed file:
+   ```bash
+   sed -i 's|<mesh name="<prefix>_base_link" file="base_link.stl"/>|<mesh name="<prefix>_base_link" file="<prefix>_base_link.stl"/>|' \
+       robots/<arm>_<eef>/<arm>_<eef>.xml
+   ```
+3. Reload in viewer to confirm the correct mesh.
+
+**Prevention going forward.** Any time arm and end-effector both ship a
+mesh whose basename appears in both `assets/` dirs, plan the rename
+ahead of time (do step 1+2 *before* step 5 of the workflow).
+
+---
+
+## 2. End-effector root body origin on the wrong face for wrist mounting
+
+**Symptom.** End-effector visually mounts at the wrist but the palm
+body extends *into the arm* (i.e. the back of the palm is hidden inside
+link6). Fingers project from the wrist origin, palm geometry is behind
+them sticking into the arm.
+
+**Cause.** Some standalone MJCFs (notably mujoco_menagerie's wonik_allegro
+left_hand.xml / right_hand.xml) place the palm body's *origin* at the
+**front face** of the palm — where the fingers attach — with the palm
+geometry extending in palm-local -Z direction. With identity quat at
+the wrist flange (the script's default after attach), this puts the
+back of the palm at wrist Z = -palm_depth = ~5–10 cm into the arm.
+
+**Detection.** Visual: open scene in MuJoCo viewer. If the eef body
+clips through the wrist, this is it.
+
+You can also check the standalone MJCF's worldbody root body for
+collision boxes at z<0:
+
+```bash
+grep -A1 '<body name="palm"' robots/<eef>/<eef>.xml | head -5
+grep '<geom .*pos="[^"]*-' robots/<eef>/<eef>.xml | head -5
+```
+
+**Fix.** Add a `pos="0 0 H"` to the prefixed root body in the combined
+XML, where H is the palm's depth (negative-Z extent of the standalone
+collision/visual). For menagerie allegro, H ≈ 0.095 m. The quat stays
+identity unless there's a separate orientation issue.
+
+```bash
+# Before
+<body name="<prefix>_palm" childclass="..." quat="0 0.707107 0 0.707107">
+# After
+<body name="<prefix>_palm" childclass="..." pos="0 0 0.095" quat="1 0 0 0">
+```
+
+**Hand-specific values seen so far.**
+
+| End-effector | Pos offset | Notes |
+|---|---|---|
+| `barrett_hand` | none (no offset needed) | Internal `bh_palm` body has its origin at the back face; identity quat works. |
+| `allegro_left` (menagerie) | `pos="0 0 0.095"` | Origin at front face. Palm body at `quat="0 1 0 1"` standalone needs override to `quat="1 0 0 0"`. |
+| `allegro_right` (menagerie) | `pos="0 0 0.095"` | Same as left. |
+
+**Prevention.** Inspect the standalone MJCF's first worldbody body
+*before* attaching: if its collision/visual boxes are at z<0 in palm
+frame, plan the pos offset.
+
+---
+
+## 3. Empty prefix is risky — default to a non-empty prefix
+
+Empty `--prefix ""` has two distinct failure modes. Internal namespacing
+(e.g. barrett's `bh_*`) only protects against the first one — not the
+second.
+
+**Failure mode A: name collision on entities.** Both arm and
+end-effector declare an entity with the same name (mesh, joint, body,
+material, etc.). With empty prefix the script errors out with
+`ValueError: repeated name 'X' in mesh` during attach.
+
+- *Example.* piper + allegro: both declare `<mesh name="base_link" .../>`.
+  Empty prefix fails with `repeated name 'base_link' in mesh`.
+
+**Failure mode B: unnamed nested `<default>` block.** The end-effector's
+standalone MJCF has a *bare* `<default>` (no `class=` attr) wrapping its
+real default classes. This is legal at the document root (where MJCF
+allows one anonymous root-default), but after attach the gripper's
+defaults get nested under the arm's outer `<default>`, and an unnamed
+nested default is illegal — MuJoCo rejects with
+`XML Error: empty class name, Element 'default'`. A non-empty prefix
+gives the bare default a name (`<default class="<prefix>main">`), which
+is well-formed.
+
+- *Example.* piper + barrett: empty prefix compiles via attach but fails
+  on the *next* load with `empty class name`. Barrett's source XML wraps
+  `<default class="bhand">` in a bare `<default>`. The internal `bh_*`
+  joint/mesh names are irrelevant — the failure is about default-class
+  naming, not entity collisions.
+
+**Detection.** Empty prefix is a footgun. Before passing it, check both:
+
+```bash
+# A: any name overlap between arm and eef defs?
+grep -hE '<(mesh|joint|body|material) name=' robots/<arm>/<arm>.xml robots/<eef>/<eef>.xml \
+  | sed -E 's/.*name="([^"]+)".*/\1/' | sort | uniq -d
+
+# B: any bare <default> in the eef (no class= attr)?
+grep -E '<default(>| [^c])' robots/<eef>/<eef>.xml
+```
+
+If either prints anything, use a non-empty prefix.
+
+**Fix.** Default to a non-empty prefix unless you've explicitly verified
+both checks above are clean. The cost of a prefix is zero; the failures
+above are silent until compile/load.
+
+| Combined | Prefix | Reason for non-empty |
+|---|---|---|
+| `piper_arm_barrett` | `"barrett_"` | Bare nested `<default>` in barrett source |
+| `piper_arm_allegro_right` | `"right_"` | `base_link` mesh name collides |
+| `piper_arm_allegro_left` | `"left_"` | Same as right |
+
+---
+
+## 4. End-effector meshes are not always under `assets/`
+
+**Symptom.** Combined model fails to load with
+`Error: could not open file 'assets/<some-mesh>.obj'`. The combined
+`assets/` dir is missing the end-effector's mesh files entirely. The
+script's stdout shows only the arm's mesh-copy line — no count for the
+gripper.
+
+**Cause.** `attach_arm_gripper.py` hard-codes the gripper's mesh source
+as `gripper_path.parent / "assets"` (around line 103). End-effectors
+whose `<compiler meshdir="..."/>` points anywhere else (e.g. `meshes`,
+`../shared/meshes`, or unset — meaning the directory of the XML file
+itself) are silently skipped: the dir doesn't exist, the loop is empty,
+no warning is printed.
+
+- *Example we hit.* `barrett_hand.xml` has
+  `<compiler meshdir="meshes" .../>`. The script looked in
+  `robots/barrett_hand/assets/`, found nothing, and emitted no warning.
+  Combined XML still references `palm_282.dae.obj` etc., causing load
+  failure.
+
+**Detection.** Right after the script finishes:
+
+```bash
+# Total files in combined assets/ should equal arm + eef (minus collisions)
+ls robots/<arm>/assets/ | wc -l       # arm count
+ls robots/<arm>_<eef>/assets/ | wc -l # combined count — should be arm + eef
+```
+
+If short by ~the eef's mesh count, this is the bug.
+
+**Fix.** Parse the gripper's actual `meshdir` from its compiler element
+and copy from there. Don't assume `assets/` *or* `meshes/` — read the
+XML:
+
+```bash
+EEF_XML=robots/<eef>/<eef>.xml
+EEF_MESHDIR=$(./.venv/bin/python -c "
+import xml.etree.ElementTree as ET, pathlib
+xml = pathlib.Path('$EEF_XML')
+root = ET.parse(xml).getroot()
+comp = root.find('compiler')
+md = (comp.get('meshdir') if comp is not None else None) or '.'
+print((xml.parent / md).resolve())
+")
+cp -n "$EEF_MESHDIR"/* robots/<arm>_<eef>/assets/
+```
+
+The `cp -n` (no-clobber) preserves any prefix-renamed meshes from
+gotcha #1. If `meshdir` is unset in the compiler element, MuJoCo treats
+mesh paths as relative to the model file itself — the snippet above
+handles that by defaulting to `'.'`.
+
+**Prevention going forward.** Always run the file-count check after the
+attach script, before bothering with the visual viewer step. A short
+combined `assets/` dir is the canary.
+
+---
+
+## 5. MuJoCo version
+
+`MjSpec.attach()` requires MuJoCo Python ≥ 3.5. Versions 3.4.x have a
+name-decoding bug that surfaces as garbled body names in the combined
+output. We hit this and upgraded `robot_sim_env/` to mujoco 3.8.0.
+
+```bash
+./.venv/bin/python -c 'import mujoco; print(mujoco.__version__)'
+# Should be >= 3.5.0
+```
+
+If older: `./robot_sim_env/bin/pip install -U "mujoco>=3.5"`.

--- a/robot-assets-skills/.claude/skills/attach-end-effector/references/workflow.md
+++ b/robot-assets-skills/.claude/skills/attach-end-effector/references/workflow.md
@@ -1,0 +1,201 @@
+# `attach-end-effector` Workflow
+
+Full step-by-step procedure for combining an arm and an end-effector
+into a single MJCF model. Pair this with `gotchas.md` — every step has
+a known way to go wrong.
+
+## Preflight
+
+1. Confirm the arm has `<site name="attachment_site" .../>` in its
+   wrist link with `pos`/`quat` defining the wrist flange frame. For
+   `piper_arm`, this is at link6 with `pos="0 0 0" quat="1 0 0 0"`.
+2. Confirm the end-effector MJCF compiles standalone:
+   ```bash
+   ./.venv/bin/python -c "
+   import mujoco
+   m = mujoco.MjModel.from_xml_path('robots/<eef>/<eef>.xml')
+   print('eef nq=', m.nq, 'nu=', m.nu)
+   "
+   ```
+3. Confirm MuJoCo Python is ≥ 3.5 (see `gotchas.md` §5).
+4. **Predict the prefix.** Default to a non-empty prefix. Empty prefix
+   has two failure modes (entity-name collisions AND bare nested
+   `<default>` blocks); see `gotchas.md` §3 for the two `grep` checks
+   that decide whether empty is actually safe. When in doubt, use a
+   non-empty prefix — the cost is zero.
+5. **Predict the pos offset.** Inspect the eef root body's collision
+   geometry. If it extends into z<0 in palm frame, plan a `pos="0 0 H"`
+   override (typically H ≈ -min(palm collision z)). See `gotchas.md`
+   §2.
+6. **Read the eef's `<compiler meshdir>`.** The attach script assumes
+   `<eef>/assets/`. If the gripper's compiler element points elsewhere
+   (e.g. `meshes`, unset, etc.), the script silently copies zero
+   gripper meshes. See `gotchas.md` §4 for the parse + copy recipe;
+   you'll need it in Fix 1 below.
+
+## Attach
+
+The bundle's venv is at `robot-assets-skills/.venv/`. The wrapped
+script `attach_arm_gripper.py` lives in the parent repo at
+`../attach_arm_gripper.py`. The script resolves relative `--arm` /
+`--gripper` / `--output` paths against its own directory (the parent
+repo), so we pass **absolute** paths via `$(pwd)/` to make the bundle's
+`robots/` the working directory.
+
+```bash
+cd robot-assets-skills/
+./.venv/bin/python ../attach_arm_gripper.py \
+    --arm     "$(pwd)/robots/<arm>/<arm>.xml" \
+    --gripper "$(pwd)/robots/<eef>/<eef>.xml" \
+    --output  "$(pwd)/robots/<arm>_<eef>" \
+    --prefix  "<prefix>_" \
+    --no-viewer
+```
+
+The script writes:
+
+- `robots/<arm>_<eef>/<arm>_<eef>.xml` — the combined MJCF
+- `robots/<arm>_<eef>/<arm>_<eef>.mjb` — binary cache (often >50 MB,
+  triggers GitHub LFS warning; see repo `.mjb` policy)
+- `robots/<arm>_<eef>/scene.xml` — wraps the MJCF with a floor +
+  lighting for viewer use
+- `robots/<arm>_<eef>/README.md` — generated description
+- `robots/<arm>_<eef>/assets/` — merged mesh dir from arm + eef
+
+## Post-attach fixes
+
+### Fix 1: gripper mesh copy (always run — script's stdout will lie)
+
+The script reports "Copying mesh assets..." but only actually copies
+files from the *arm's* `assets/` dir if the gripper's mesh dir isn't
+literally `assets/`. See `gotchas.md` §4. Always do this:
+
+```bash
+# Resolve the gripper's actual mesh dir from its <compiler meshdir="...">
+EEF_XML=robots/<eef>/<eef>.xml
+EEF_MESHDIR=$(./.venv/bin/python -c "
+import xml.etree.ElementTree as ET, pathlib
+xml = pathlib.Path('$EEF_XML')
+comp = ET.parse(xml).getroot().find('compiler')
+md = (comp.get('meshdir') if comp is not None else None) or '.'
+print((xml.parent / md).resolve())
+")
+cp -n "$EEF_MESHDIR"/* robots/<arm>_<eef>/assets/
+```
+
+`cp -n` (no-clobber) preserves anything copied by the script and any
+prefix-renamed files from Fix 2 below.
+
+Sanity-check the merged dir picked up the eef meshes:
+
+```bash
+echo "arm:      $(ls robots/<arm>/assets/ | wc -l)"
+echo "eef:      $(ls "$EEF_MESHDIR" | wc -l)"
+echo "combined: $(ls robots/<arm>_<eef>/assets/ | wc -l)"
+# combined should equal arm + eef (minus same-name overwrites — see Fix 2)
+```
+
+### Fix 2: mesh-filename collisions (always check)
+
+```bash
+# List any size mismatches between source eef assets and merged combined assets
+python3 -c "
+from pathlib import Path
+eef = Path('$EEF_MESHDIR')  # resolved by Fix 1 above
+combined = Path('robots/<arm>_<eef>/assets')
+for f in eef.iterdir():
+    cf = combined / f.name
+    if cf.exists() and cf.stat().st_size != f.stat().st_size:
+        print('COLLISION:', f.name, f.stat().st_size, '->', cf.stat().st_size)
+"
+```
+
+For each collision: see `gotchas.md` §1 fix.
+
+### Fix 3: pos offset (when end-effector clips into the arm)
+
+Edit the combined MJCF in-place to add the pos offset on the prefixed
+root body:
+
+```bash
+sed -i 's|<body name="<prefix>_<root>" childclass="<prefix>_<class>" quat="<auto-quat>">|<body name="<prefix>_<root>" childclass="<prefix>_<class>" pos="0 0 <H>" quat="1 0 0 0">|' \
+    robots/<arm>_<eef>/<arm>_<eef>.xml
+```
+
+See `gotchas.md` §2 for the per-end-effector H values.
+
+## Verify
+
+1. **Compile + count check:**
+   ```bash
+   ./.venv/bin/python -c "
+   import mujoco
+   m = mujoco.MjModel.from_xml_path('robots/<arm>_<eef>/<arm>_<eef>.xml')
+   print('combined nq=', m.nq, 'nu=', m.nu, 'nbody=', m.nbody)
+   for i in range(m.nu):
+       print(' ', i, m.actuator(i).name)
+   "
+   ```
+   Expected: `nq = arm.nq + eef.nq`, `nu = arm.nu + eef.nu`, all
+   actuator names prefixed correctly.
+
+2. **Visual check** (must — collisions and pos offsets are visual bugs
+   that compile cleanly):
+   ```bash
+   DISPLAY=:5 ./.venv/bin/python -m mujoco.viewer \
+       --mjcf robots/<arm>_<eef>/scene.xml
+   ```
+   Drag actuator sliders to confirm:
+   - Arm joints move only the arm.
+   - End-effector joints move only the end-effector.
+   - End-effector mounts flush at the wrist flange (no gap, no clipping).
+   - Visual geometry looks correct (no "mystery box" — that's a mesh
+     collision; see `gotchas.md` §1).
+
+## Register
+
+Drop a `robot.json` in `robots/<arm>_<eef>/`. Mjcf-only registration
+per the `ur5e`/`piper`/`barrett` convention:
+
+```json
+{
+  "robot": {
+    "name": "pathonai/<arm>-<eef>",
+    "display_name": "<Arm> + <Eef>",
+    "description": "<arm> with <eef> mounted at the wrist (combined system)",
+    "visibility": "official",
+    "is_verified": true,
+    "is_featured": false
+  },
+  "version": {
+    "version": "1.0.0",
+    "is_stable": true,
+    "dof": <arm.dof + eef.dof>,
+    "motor_type": "<arm.motor_type>",
+    "designer": "PathOn AI",
+    "urdf_file": null,
+    "mjcf_file": "<arm>_<eef>.xml",
+    "meshes_dir": "assets",
+    "changelog": "Initial release - <arm> v<v> + <eef> v<v> via attach_arm_gripper.py with prefix '<prefix>_'. <Notes on any pos/mesh-rename fixes applied.>"
+  }
+}
+```
+
+## Commit (when registering the combined model upstream)
+
+The bundle's `robots/` is gitignored — nothing here gets committed
+from inside the bundle. To *register* a combined model in the parent
+repo (`pathonai_robot_assets`), copy the combined folder out:
+
+```bash
+cp -r robots/<arm>_<eef>/ ../robots/<arm>_<eef>/
+cd ..
+git add robots/<arm>_<eef>/
+git commit -m "Add <arm>_<eef> combined model"
+git push origin main
+```
+
+The combined `.mjb` is large (~50–80 MB). Current parent-repo policy
+is to commit it (matching `piper_arm_barrett`); GitHub will warn but
+accept. If `.mjb` ever gets gitignored, document the regen recipe in
+the combined `README.md`.

--- a/robot-assets-skills/.claude/skills/attach-end-effector/requirements.txt
+++ b/robot-assets-skills/.claude/skills/attach-end-effector/requirements.txt
@@ -1,0 +1,9 @@
+# attach-end-effector — runtime requirements
+#
+# The skill calls MjSpec.attach() (>=3.5) and then post-processes the
+# resulting XML, so the only runtime dep is mujoco itself. lxml is for
+# the post-attach XML rewrite (mesh-rename + pos offset) without
+# touching the rest of the document.
+
+mujoco>=3.5
+lxml>=4.9

--- a/robot-assets-skills/.claude/skills/mjcf-to-urdf/SKILL.md
+++ b/robot-assets-skills/.claude/skills/mjcf-to-urdf/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: mjcf-to-urdf
+description: Convert an MJCF (MuJoCo's XML format) to URDF for downstream consumers that don't speak MJCF (RViz, pinocchio, ROS-based motion planning, etc.). The conversion is lossy — `<equality>` constraints, position actuators, contact excludes, and keyframes are all dropped. Use this skill ONLY when a URDF-only consumer needs the kinematic tree; do not use the converted URDF for dynamics.
+---
+
+# mjcf-to-urdf
+
+Wrap `convert_mjcf_urdf.py --to-urdf` (which uses
+`mjcf-urdf-simple-converter`). Lower-priority skill in the bundle —
+URDF→MJCF is the direction we usually want, since MJCF is more
+expressive. The reverse is for downstream tools that don't speak MJCF.
+
+The conversion preserves the kinematic tree (links, joints, parent/child,
+visual/collision meshes, joint limits) but **drops** several MJCF-only
+features:
+
+1. **`<equality>` constraints disappear.** Any joint coupling expressed
+   as `polycoef` (the MJCF equivalent of URDF mimic joints) is lost.
+   Joints that should be coupled become independent in the URDF.
+2. **Actuators are dropped.** URDF has no actuator concept — joints
+   exist, nothing drives them. Downstream consumers must add their own
+   joint controllers.
+3. **Contact excludes don't survive.** URDF has no contact-exclusion
+   element. Anything that was excluded becomes an active collision
+   pair in the URDF — usually fine for a *visualization* consumer
+   like RViz, but breaks anything doing physics from the URDF.
+4. **Keyframes are dropped.** Any rest-pose snapshots in the MJCF are
+   discarded.
+5. **Position actuators with `kp`/`kv` are dropped.** Any tuning is
+   lost; the URDF has no analog.
+
+The output is **for kinematic visualization or planning, not
+dynamics**. If the consumer simulates from the URDF, they'll get
+wrong results.
+
+## When to use this skill
+
+- A downstream consumer (RViz, pinocchio, MoveIt, IK libraries) needs
+  a URDF and the canonical model is MJCF.
+- You only need the kinematic tree: forward kinematics, IK, collision
+  visualization. You don't need dynamics fidelity.
+
+## When NOT to use this skill
+
+- You need to simulate dynamics from the URDF — converting will look
+  fine but produce wrong physics. Re-export from the MJCF source each
+  time, or use `urdf-to-mjcf` in reverse only after re-tuning.
+- A URDF version of the robot already exists upstream — adopt that
+  instead. A hand-maintained URDF is almost always more accurate than
+  one auto-converted from MJCF.
+- The MJCF uses `<equality>` constraints that the consumer needs (e.g.
+  underactuated hand) — the consumer will silently get the wrong
+  kinematics. In this case, regenerate the URDF from the *original*
+  source (not from the MJCF), or document the lost coupling in the URDF
+  comments.
+
+## Workflow
+
+1. **Confirm the consumer actually needs URDF.** Many tools support
+   MJCF directly (mink, mujoco-python-viewer, IsaacSim) — skip this
+   skill if so.
+2. **Check upstream for a hand-maintained URDF.** If one exists, use
+   it. Don't auto-convert.
+3. Run the converter (see Commands).
+4. **Verify mesh paths.** The converter may produce
+   `meshdir`-relative paths that don't resolve under URDF's normal
+   `package://` or relative-to-URDF conventions. Manually inspect.
+5. **Document what was lost** in the URDF's leading comment so future
+   readers know they're looking at a partial representation.
+6. (Optional) Drop a `robot.json` if registering upstream — but URDF
+   from MJCF conversion typically isn't registered as the canonical;
+   it's a derived artifact for one consumer.
+
+## Commands
+
+Run from the bundle root with the bundle-local venv. Pass an absolute
+input path so the script doesn't try to resolve it relative to the
+parent repo:
+
+```bash
+cd robot-assets-skills/
+./.venv/bin/python ../convert_mjcf_urdf.py \
+    "$(pwd)/robots/<robot>/<robot>.xml" --to-urdf
+```
+
+By default the output goes to the same directory with `.urdf`
+extension. To pick an explicit output path:
+
+```bash
+./.venv/bin/python ../convert_mjcf_urdf.py \
+    "$(pwd)/robots/<robot>/<robot>.xml" \
+    "$(pwd)/robots/<robot>/<robot>.urdf"
+```
+
+Verify the URDF parses:
+
+```bash
+./.venv/bin/python -c "
+import mujoco
+m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.urdf')
+print('nq=', m.nq, 'nu=', m.nu, 'nbody=', m.nbody)
+"
+```
+
+`nu = 0` is **expected** — URDF has no actuators. Anything in the
+source MJCF's `<actuator>` block is gone.
+
+If `.venv/` is missing or broken, bootstrap per `AGENTS.md`'s "Python
+environment" section.
+
+## References
+
+- Step-by-step procedure: `references/workflow.md`
+- The losses with concrete examples: `references/gotchas.md`

--- a/robot-assets-skills/.claude/skills/mjcf-to-urdf/references/gotchas.md
+++ b/robot-assets-skills/.claude/skills/mjcf-to-urdf/references/gotchas.md
@@ -1,0 +1,156 @@
+# `mjcf-to-urdf` Gotchas
+
+What gets dropped in the conversion, and how to handle each loss.
+
+URDF is a strict subset of what MJCF can express. The conversion is
+**lossy by definition** — these aren't bugs in the converter, they're
+limits of the URDF spec. Each loss has a different impact depending
+on what the consumer does with the URDF.
+
+---
+
+## 1. `<equality>` constraints are dropped
+
+**What's lost.** Any joint coupling expressed as
+`<equality><joint .../>` with a `polycoef` becomes nothing — both
+joints become independent in the URDF.
+
+**Impact.**
+- *RViz / pure visualization:* low — sliders behave independently,
+  but the model still renders. Just won't look mechanically coupled.
+- *Pinocchio / FK / IK:* medium — IK produces solutions that are
+  unreachable on the real hardware (since the hardware has the
+  coupling).
+- *Dynamics simulation:* high — physics is wrong.
+
+**Workaround.** If the consumer supports URDF `<mimic>`, hand-edit the
+generated URDF to add `<mimic>` clauses on the should-be-driven joints:
+
+```xml
+<joint name="<dependent>" type="revolute">
+  <mimic joint="<primary>" multiplier="<k>" offset="0"/>
+  ...
+</joint>
+```
+
+`<mimic>` is the URDF-side equivalent of the polycoef linear case
+(`joint = multiplier * primary + offset`). Polynomial polycoefs (`c2`,
+`c3`, `c4` non-zero) have no URDF equivalent — those are dropped
+permanently.
+
+---
+
+## 2. Actuators are dropped
+
+**What's lost.** The MJCF's `<actuator>` block (positions, motors,
+velocities, kp/kv tuning) doesn't appear in URDF — URDF has no
+actuator concept.
+
+**Impact.** The URDF kinematic tree exists, but there's no concept of
+"controlled" vs "free" joints. Downstream consumers must:
+- Decide which joints to control themselves (e.g. via a YAML config
+  for MoveIt).
+- Re-tune any kp/kv equivalents in their own controller.
+
+**Workaround.** If the consumer needs to know which joints were
+actuated, document them in a sidecar (e.g. `actuators.yaml`):
+
+```yaml
+controlled_joints:
+  - name: <joint-name>
+    actuator: position
+    ctrlrange: [<min>, <max>]
+    kp: <value>
+    kv: <value>
+```
+
+---
+
+## 3. Contact excludes don't survive
+
+**What's lost.** `<contact><exclude>` entries (the "these two links
+shouldn't collide even though they geometrically overlap" hints) are
+not representable in URDF.
+
+**Impact.**
+- *RViz:* low — RViz doesn't do collision checking. No visible
+  effect.
+- *MoveIt collision checking:* medium — MoveIt may flag normally-OK
+  rest-pose configurations as in collision. MoveIt has its own
+  `disable_collisions` mechanism in the SRDF that can reproduce the
+  exclusions, but it's a separate file.
+- *Physics simulation from URDF:* high — joints stick at the same
+  rest-pose collisions the MJCF was built to ignore.
+
+**Workaround.** If the consumer is MoveIt, generate the SRDF
+exclusions list from the MJCF's `<contact><exclude>` block manually:
+
+```xml
+<!-- in <robot-name>.srdf -->
+<disable_collisions link1="<palm>" link2="<finger-1>" reason="Adjacent"/>
+```
+
+For other consumers, document the excluded pairs in the URDF's leading
+comment.
+
+---
+
+## 4. Keyframes are dropped
+
+**What's lost.** Any `<keyframe>` blocks (rest-pose snapshots,
+named configurations) don't appear in URDF.
+
+**Impact.** Mostly low — keyframes are convenience features. The
+robot's home position is implicit (joint values from `<joint range>`
+defaults). Document any non-trivial keyframes in a sidecar if needed.
+
+---
+
+## 5. `<default>` classes are flattened or dropped
+
+**What's lost.** MJCF's hierarchical `<default>` classes don't
+translate to URDF — every element gets explicit attributes inline,
+or the default goes away if there's no URDF analog (e.g. `kp`,
+`damping` on positions).
+
+**Impact.** The URDF tends to be more verbose than the MJCF source.
+Otherwise no semantic loss for the kinematic tree.
+
+---
+
+## 6. Mesh path prefixes may need fixing
+
+**Symptom.** RViz / pinocchio fails with "could not find mesh".
+
+**Cause.** MJCF references meshes via `<compiler meshdir="...">` +
+relative `<mesh file="...">`. URDF references via `package://` or
+relative-to-URDF paths. The converter writes one of:
+- `<mesh filename="meshdir/mesh.stl"/>` — relative to URDF, often
+  works if URDF and meshes are in the same dir.
+- `<mesh filename="package://<...>"/>` — only works inside ROS.
+- `<mesh filename="file:///abs/path/mesh.stl"/>` — absolute, breaks
+  on move.
+
+**Fix.** Inspect the converted URDF's mesh refs and rewrite if needed.
+Most common: ensure paths are relative to the URDF location:
+
+```bash
+sed -i 's|filename="package://[^/]*/|filename="|g' robots/<robot>/<robot>.urdf
+sed -i 's|filename="file:///[^"]*meshes/|filename="meshes/|g' robots/<robot>/<robot>.urdf
+```
+
+Verify in RViz before declaring done.
+
+---
+
+## Should I even use this skill?
+
+Quick decision tree:
+
+- *Consumer supports MJCF natively* (mink, MuJoCo, IsaacSim, MJX): **no**, skip the conversion.
+- *Hand-maintained URDF exists upstream*: **no**, use that instead.
+- *Consumer is RViz for visualization only*: **yes**, the conversion is fine.
+- *Consumer is pinocchio / MoveIt / ROS*: **yes**, but be ready to
+  hand-edit `<mimic>`, write an SRDF, and re-tune controllers.
+- *Consumer simulates dynamics from URDF*: **no**, results will be
+  wrong. Either keep MJCF or hand-write the URDF.

--- a/robot-assets-skills/.claude/skills/mjcf-to-urdf/references/workflow.md
+++ b/robot-assets-skills/.claude/skills/mjcf-to-urdf/references/workflow.md
@@ -1,0 +1,168 @@
+# `mjcf-to-urdf` Workflow
+
+Step-by-step procedure for converting MJCF to URDF for a downstream
+URDF-only consumer.
+
+## Preflight
+
+1. **Confirm the consumer can't take MJCF directly.** Skip this skill
+   for any consumer that supports MJCF natively (MuJoCo, mink, MJX,
+   IsaacSim, mujoco-python-viewer, etc.). The conversion is lossy;
+   skipping it is always preferable.
+
+2. **Check upstream for a hand-maintained URDF first.** Most robots
+   that have an MJCF also have a URDF (often what the MJCF was
+   originally built from). A hand-maintained URDF is always better
+   than auto-converting.
+
+   ```bash
+   # If the MJCF came from mujoco_menagerie, the source URDF is
+   # often in the same upstream package or a manufacturer repo.
+   grep -i 'urdf\|source\|original' robots/<robot>/<robot>.xml
+   grep -i 'urdf\|source\|original' robots/<robot>/README.md  2>/dev/null
+   ```
+
+3. **Inventory what will be lost.** Note these counts before
+   conversion — they tell you what the consumer needs to handle:
+
+   ```bash
+   ./.venv/bin/python -c "
+   import mujoco
+   m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.xml')
+   print('equality:', m.neq)
+   print('actuators:', m.nu)
+   print('keyframes:', m.nkey)
+   "
+   grep -c '<exclude' robots/<robot>/<robot>.xml
+   ```
+
+   Each of these gets dropped — if any are non-zero, see the
+   per-loss workarounds in `gotchas.md`.
+
+## Convert
+
+From the bundle root, with the bundle-local venv:
+
+```bash
+cd robot-assets-skills/
+./.venv/bin/python ../convert_mjcf_urdf.py \
+    "$(pwd)/robots/<robot>/<robot>.xml" --to-urdf
+```
+
+Output goes to `robots/<robot>/<robot>.urdf` by default.
+
+Verify it parses:
+
+```bash
+./.venv/bin/python -c "
+import mujoco
+m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.urdf')
+print('parsed: nq=', m.nq, 'nbody=', m.nbody)
+"
+```
+
+`nu = 0` is **expected** — URDF has no actuators (gotcha §2).
+
+## Post-convert fixes
+
+### Fix 1: Mesh paths
+
+Inspect the URDF's mesh refs:
+
+```bash
+grep 'filename=' robots/<robot>/<robot>.urdf | sort -u | head
+```
+
+If they use `package://` (ROS-only) or `file://` (absolute), rewrite to
+URDF-relative paths so the URDF works outside ROS:
+
+```bash
+sed -i 's|filename="package://[^/]*/|filename="|g' robots/<robot>/<robot>.urdf
+sed -i 's|filename="file:///[^"]*meshes/|filename="meshes/|g' robots/<robot>/<robot>.urdf
+```
+
+Test in your target consumer (RViz if visualizing, pinocchio if doing
+FK/IK).
+
+### Fix 2: Re-add `<mimic>` for any dropped equality constraints
+
+If the preflight showed `equality > 0`, those joint couplings were
+lost. Hand-edit the URDF to add `<mimic>` clauses where the consumer
+needs them (URDF has `<mimic>` for the simple linear case — but no
+analog for polynomial polycoefs). See `gotchas.md` §1.
+
+### Fix 3: Document losses in URDF leading comment
+
+Add a comment at the top of the converted URDF so future readers
+know what's missing:
+
+```xml
+<?xml version="1.0"?>
+<!--
+This URDF was auto-converted from <robot>.xml (MJCF source).
+Lost in conversion:
+- <equality> constraints (N coupled joints became independent)
+- <actuator> block (re-tune controller separately)
+- <contact><exclude> entries (re-derive in SRDF if using MoveIt)
+- <keyframe> block (M named poses; document elsewhere)
+
+Use only for kinematic tasks (visualization, FK, IK). Do NOT use
+for dynamics simulation; results will be wrong. Re-export from
+MJCF source if needed.
+-->
+<robot name="<robot>">
+...
+```
+
+## Verify
+
+1. **Open in the target consumer** (RViz, pinocchio script, MoveIt
+   setup assistant, etc.). The conversion is for that specific
+   consumer; verify there.
+
+2. **For RViz:** check all meshes load and joints can be commanded
+   from the joint-state publisher GUI.
+
+3. **For pinocchio:** confirm FK matches MJCF FK at the same joint
+   values:
+
+   ```python
+   import mujoco, pinocchio as pin, numpy as np
+
+   mj_m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.xml')
+   mj_d = mujoco.MjData(mj_m)
+   pin_m = pin.buildModelFromUrdf('robots/<robot>/<robot>.urdf')
+   pin_d = pin_m.createData()
+
+   q = np.zeros(mj_m.nq)  # or some test pose
+   mj_d.qpos[:] = q
+   mujoco.mj_forward(mj_m, mj_d)
+
+   pin.forwardKinematics(pin_m, pin_d, q)
+
+   # Compare end-effector / wrist site positions; expect close match
+   # (small differences from slightly different inertia/origin frames are OK)
+   ```
+
+   FK mismatches mean either mesh-frame discrepancies or dropped
+   `<equality>` (the simulated joints are different).
+
+## Register (rarely)
+
+URDFs auto-converted from MJCF typically aren't registered upstream
+as the canonical URDF — they're derived artifacts for one consumer.
+If you do register one, document the conversion in the changelog:
+
+```json
+{
+  "version": {
+    "version": "1.0.0-derived",
+    "is_stable": false,
+    "urdf_file": "<robot>.urdf",
+    "changelog": "Auto-converted from <robot>.xml (MJCF) via mjcf-to-urdf skill. LOSSY — see leading comment in URDF for details. For kinematic use only."
+  }
+}
+```
+
+`is_stable: false` is intentional; consumers should know this URDF is
+derived.

--- a/robot-assets-skills/.claude/skills/mjcf-to-urdf/requirements.txt
+++ b/robot-assets-skills/.claude/skills/mjcf-to-urdf/requirements.txt
@@ -1,0 +1,7 @@
+# mjcf-to-urdf — runtime requirements
+#
+# `mjcf-urdf-simple-converter` does the actual conversion;
+# `mujoco` is needed to verify the output parses.
+
+mujoco>=3.5
+mjcf-urdf-simple-converter

--- a/robot-assets-skills/.claude/skills/urdf-to-mjcf/SKILL.md
+++ b/robot-assets-skills/.claude/skills/urdf-to-mjcf/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: urdf-to-mjcf
+description: Convert a URDF to MJCF (MuJoCo's XML format) and post-tune the result so it actually simulates correctly. MuJoCo's URDF loader silently drops mimic joints, often produces 100x oversized inertias, generates no actuators, and emits no contact excludes — so a raw conversion is rarely usable as-is. Use this skill when bringing a new robot/hand from a URDF source into MuJoCo. Always check mujoco_menagerie first — if a hand-tuned MJCF already exists there, adopt it instead of running the converter.
+---
+
+# urdf-to-mjcf
+
+Wrap `convert_mjcf_urdf.py --to-mjcf` (which uses MuJoCo's built-in URDF
+loader via `mjcf-urdf-simple-converter`), then post-tune the output
+because the auto-conversion is rarely usable as-is.
+
+The script gets the kinematic tree right but does **not** handle:
+
+1. **Mimic joints get silently dropped.** MuJoCo's URDF loader has no
+   way to express URDF `<mimic>` semantics. All mimic'd joints become
+   independent free joints; the underlying coupling is lost.
+2. **Inertias are often 100x oversized.** Stock URDFs from xacro/SDF
+   pipelines frequently use placeholder inertia values that produce
+   absurd dynamics in MuJoCo (e.g. fingers that won't move at any
+   reasonable kp).
+3. **No actuators.** The output has joints but nothing drives them.
+   No actuator block at all.
+4. **No contact excludes.** Adjacent links that touch in the rest pose
+   (palm↔first-knuckle pairs are the typical case) get treated as
+   active contacts and the joint physically can't reach its
+   commanded angle.
+5. **No `autolimits`, no `implicitfast` integrator.** Defaults that
+   matter for stable dexterous-hand sim aren't set.
+
+**Strong preference: check `mujoco_menagerie` first.** If your robot
+or hand already lives in
+`https://github.com/google-deepmind/mujoco_menagerie`, adopt that
+MJCF verbatim — the MuJoCo team has already tuned it, and re-running
+the converter on a URDF will produce a strictly worse result.
+
+These post-tune fixes are documented in `references/gotchas.md` and
+the step-by-step is in `references/workflow.md`.
+
+## When to use this skill
+
+- A new robot/hand with a URDF you need to simulate in MuJoCo and no
+  upstream MJCF (menagerie or otherwise) exists.
+- Your existing URDF is the source of truth (e.g. you maintain it for
+  RViz/pinocchio) and you need an MJCF for sim.
+
+## When NOT to use this skill
+
+- An upstream MJCF exists in `mujoco_menagerie` or the manufacturer's
+  repo — adopt it instead. Re-tuning is wasted work.
+- You only need URDF (e.g. for RViz/pinocchio) — skip MJCF entirely.
+- The robot is going to be combined with another via
+  `attach-end-effector` and only that combined model needs to
+  simulate — convert the components individually first.
+
+## Workflow
+
+1. **Check `mujoco_menagerie` first.** If the robot is there, copy
+   its MJCF into `robots/<robot>/<robot>.xml` and stop. Don't run
+   the converter.
+2. **Verify the URDF loads in MuJoCo standalone.** If MuJoCo can't
+   parse it, the converter won't help — fix the URDF first.
+3. Run the converter (see Commands).
+4. **Post-tune the MJCF.** Walk through the five fix categories in
+   `references/gotchas.md`: mimics→`<equality>`, inertias,
+   actuators, contact excludes, compiler/option attributes.
+5. **Verify in the viewer.** Each actuator slider should drive the
+   intended joint(s) to the commanded angle without numerical
+   blowup or contact-blocked motion.
+6. Drop a `robot.json` (mjcf registration; if URDF + MJCF use
+   different mesh dirs, set `urdf_file: null` per ur5e/piper convention).
+
+## Commands
+
+Run from the bundle root with the bundle-local venv. The wrapped
+script is in the parent repo at `../convert_mjcf_urdf.py`. Pass an
+**absolute** input path so the script doesn't try to resolve it
+relative to the parent repo:
+
+```bash
+cd robot-assets-skills/
+./.venv/bin/python ../convert_mjcf_urdf.py \
+    "$(pwd)/robots/<robot>/<robot>.urdf" --to-mjcf
+```
+
+By default the output goes to the same directory with `.xml`
+extension. To pick an explicit output path:
+
+```bash
+./.venv/bin/python ../convert_mjcf_urdf.py \
+    "$(pwd)/robots/<robot>/<robot>.urdf" \
+    "$(pwd)/robots/<robot>/<robot>.xml"
+```
+
+Verify the converted MJCF compiles:
+
+```bash
+./.venv/bin/python -c "
+import mujoco
+m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.xml')
+print('nq=', m.nq, 'nu=', m.nu, 'nbody=', m.nbody)
+"
+```
+
+`nu` = 0 right after conversion is **expected** (no actuators yet);
+that's one of the post-tune fixes. After fixing, `nu` should equal the
+number of actuated joints.
+
+View interactively to drive the sliders (`DISPLAY=:5` on our headless box):
+
+```bash
+DISPLAY=:5 ./.venv/bin/python -m mujoco.viewer \
+    --mjcf robots/<robot>/<robot>.xml
+```
+
+If `.venv/` is missing or broken, bootstrap per `AGENTS.md`'s "Python
+environment" section.
+
+## References
+
+- Step-by-step procedure: `references/workflow.md`
+- The five post-tune fix categories with concrete recipes:
+  `references/gotchas.md`

--- a/robot-assets-skills/.claude/skills/urdf-to-mjcf/references/gotchas.md
+++ b/robot-assets-skills/.claude/skills/urdf-to-mjcf/references/gotchas.md
@@ -1,0 +1,206 @@
+# `urdf-to-mjcf` Gotchas
+
+The five post-tune fix categories that turn a raw conversion into a
+usable MJCF. Read this before declaring a conversion "done".
+
+A raw output that *compiles* and *opens in the viewer* can still be
+unusable if any of these are wrong (fingers won't move, joints fly
+off, dynamics blow up at first contact).
+
+---
+
+## 1. Mimic joints are silently dropped
+
+**Symptom.** The standalone viewer shows the right number of sliders
+*on the URDF side* (with mimic joints folded in), but the converted
+MJCF shows one slider per *raw* joint — including the mimic'd ones.
+Driving the "primary" joint doesn't move the "mimic" joint.
+
+**Cause.** MuJoCo's URDF loader has no way to express URDF
+`<mimic>` semantics in pure MJCF — there's no `mimic` element. The
+loader silently drops the relationship; both joints become independent
+hinges.
+
+**Concrete example we hit.** Barrett: 8 joints in the URDF (4 mimic
+relationships), 4 actuators in the original SDK. The raw converted
+MJCF had 8 free joints and zero coupling — finger phalanges flopped
+independently of their proximals.
+
+**Fix.** Add `<equality><joint .../>` blocks for each mimic
+relationship:
+
+```xml
+<equality>
+  <joint joint1="<mimic-joint>" joint2="<primary-joint>"
+         polycoef="0 <multiplier> 0 0 0"/>
+</equality>
+```
+
+The `polycoef` is `c0 c1 c2 c3 c4` for `joint1 = c0 + c1*joint2 + c2*joint2^2 + ...`.
+For a simple URDF mimic (`joint = multiplier * primary + offset`), use
+`polycoef="<offset> <multiplier> 0 0 0"`.
+
+**Concrete example for barrett:**
+
+```xml
+<equality>
+  <joint joint1="bh_j33_joint" joint2="bh_j32_joint" polycoef="0 0.344262295082 0 0 0"/>
+  <joint joint1="bh_j13_joint" joint2="bh_j12_joint" polycoef="0 0.344262295082 0 0 0"/>
+  <joint joint1="bh_j21_joint" joint2="bh_j11_joint" polycoef="0 1 0 0 0"/>
+  <joint joint1="bh_j23_joint" joint2="bh_j22_joint" polycoef="0 0.344262295082 0 0 0"/>
+</equality>
+```
+
+**Detection.** Diff the joint count vs. actuator count of the *original*
+URDF (joints minus mimics) — that's how many actuators the converted
+MJCF should have after you also add actuators (gotcha §3). If
+joint-count > actuator-count, you have unhandled mimics.
+
+---
+
+## 2. Inertias are often 100x oversized
+
+**Symptom.** Joints don't respond to commanded actuator targets even
+with very high `kp`; or, the simulation is sluggish; or, contact
+forces are unrealistic.
+
+**Cause.** Many URDFs (especially xacro-generated ones) ship
+placeholder inertia values that are much larger than physically
+correct. URDF doesn't enforce physical plausibility; MuJoCo does the
+math literally. A 100x inertia means `kp` needs to be 100x higher to
+get the same response.
+
+**Detection.** For each link, compare:
+
+```python
+import mujoco
+m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.xml')
+for i in range(m.nbody):
+    body = m.body(i)
+    print(body.name, 'mass=', body.mass[0], 'diaginertia=', body.inertia)
+```
+
+Sanity rules of thumb for finger-sized links:
+- mass: 0.01–0.05 kg per phalanx, ~0.5 kg for palm
+- diaginertia: 1e-6 to 5e-5 for phalanges, ~1e-3 for palm
+
+Anything 100x outside these ranges is suspect.
+
+**Fix.** Override the link's inertial block in the converted MJCF:
+
+```xml
+<body name="..." pos="..." quat="...">
+  <inertial pos="0 0 0" mass="0.05" diaginertia="2e-5 2e-5 2e-5"/>
+  ...
+</body>
+```
+
+For dexterous hands specifically, the menagerie barrett/allegro
+inertias are good reference values to copy from.
+
+---
+
+## 3. No actuators — joints exist but nothing drives them
+
+**Symptom.** Viewer shows joint sliders but they don't actually drive
+any motion (only adjust `qpos` directly, which gets corrected each
+step).
+
+**Cause.** MuJoCo's URDF loader doesn't generate `<actuator>` blocks.
+URDF has no concept of an actuator/motor as a first-class element.
+
+**Fix.** Add a `<position>` (or `<motor>` / `<velocity>`) actuator per
+controlled joint:
+
+```xml
+<default class="<robot>">
+  <position ctrlrange="<min> <max>" forcerange="-10 10" kp="10" kv="0.5"/>
+</default>
+
+...
+
+<actuator>
+  <position class="<robot>" name="<actuator-name>" joint="<joint-name>"
+            ctrlrange="<joint min> <joint max>"/>
+  ...
+</actuator>
+```
+
+For underactuated hands (joints coupled via `<equality>` from gotcha §1):
+add actuators only for the **primary** joints, not the mimic'd ones.
+Barrett has 4 actuators driving 8 joints; allegro has 16
+(no mimics).
+
+`kp` and `kv` are starting points — tune in the viewer until the joint
+tracks the commanded angle smoothly without oscillation.
+
+---
+
+## 4. No contact excludes — palm-knuckle pairs block motion
+
+**Symptom.** The actuator sees the commanded target but the joint
+sticks at some lower value (e.g. spread joint stuck at 1.74 rad
+instead of 3.14). High actuator force fails to overcome it. Looks
+mechanical, not numerical.
+
+**Cause.** Adjacent links that touch in the rest pose are being treated
+as active contacts. Increasing actuator force pushes harder on the
+contact. Common culprit: palm and the proximal link of a finger
+(`bh_j11` spread getting blocked by palm/finger collision).
+
+**Fix.** Add `<contact><exclude>` for palm↔first-link pairs (and any
+others adjacent in rest pose):
+
+```xml
+<contact>
+  <exclude body1="<palm-body>" body2="<finger-1-link>"/>
+  <exclude body1="<palm-body>" body2="<finger-2-link>"/>
+  <exclude body1="<palm-body>" body2="<thumb-1-link>"/>
+</contact>
+```
+
+**Detection.** With the actuator targeted at its joint limit, set a
+breakpoint and inspect `data.contact[i]` for any contact pair between
+palm and first-link bodies. If found, exclude.
+
+---
+
+## 5. Compiler / option defaults that matter
+
+The converter doesn't set these but they're load-bearing for stable
+dexterous-hand sim:
+
+```xml
+<compiler angle="radian" autolimits="true" .../>
+<option integrator="implicitfast"/>
+```
+
+- `autolimits="true"` — joint range checking from the joint definition
+  (otherwise you can drive past the limit).
+- `implicitfast` integrator — much more stable than the default for
+  stiff actuator gains (kp=10+) typical in dex hands.
+
+Add these to the converted MJCF's `<compiler>` and `<option>` elements.
+
+---
+
+## Mesh directory split convention
+
+URDF often uses `meshes/`, MuJoCo often uses `assets/`. If your URDF
+references `meshes/<file>.STL` and your MJCF will reference
+`assets/<file>.stl`, the registration in `robot.json` can't list both
+in `meshes_dir`. Convention from `ur5e`/`piper`/`barrett`:
+
+```json
+{
+  "version": {
+    "urdf_file": null,
+    "mjcf_file": "<robot>.xml",
+    "meshes_dir": "assets"
+  }
+}
+```
+
+Set `urdf_file: null` (URDF stays on disk for RViz/pinocchio
+consumers but isn't registered upstream). See `pathonai_robot_assets`
+issue #40 for the schema gap that drove this convention.

--- a/robot-assets-skills/.claude/skills/urdf-to-mjcf/references/workflow.md
+++ b/robot-assets-skills/.claude/skills/urdf-to-mjcf/references/workflow.md
@@ -1,0 +1,183 @@
+# `urdf-to-mjcf` Workflow
+
+Full step-by-step procedure for converting a URDF to a working MJCF.
+Pair this with `gotchas.md` — the auto-conversion is the *easy* part;
+the post-tune is where every iteration of this skill has been spent.
+
+## Preflight
+
+1. **Check `mujoco_menagerie` first.** Search
+   `https://github.com/google-deepmind/mujoco_menagerie` for your
+   robot:
+   ```bash
+   git clone --depth 1 https://github.com/google-deepmind/mujoco_menagerie.git /tmp/mujoco_menagerie
+   ls /tmp/mujoco_menagerie/ | grep -i <robot-name>
+   ```
+   If found, copy its MJCF + assets into `robots/<robot>/` and **stop
+   — don't run the converter**. The MuJoCo team has tuned it; you
+   won't beat their work by re-running URDF→MJCF.
+
+2. Confirm the URDF parses standalone (sanity check that the URDF
+   itself isn't broken):
+   ```bash
+   ./.venv/bin/python -c "
+   import mujoco
+   m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.urdf')
+   print('parsed: nq=', m.nq, 'nbody=', m.nbody)
+   "
+   ```
+   If MuJoCo can't parse it, fix the URDF before the converter; the
+   converter uses the same loader.
+
+3. **Inventory the URDF.** Note these counts before conversion — you'll
+   need them to detect dropped mimics:
+   ```bash
+   grep -c '<joint name=' robots/<robot>/<robot>.urdf       # total joints (incl mimic)
+   grep -c '<mimic ' robots/<robot>/<robot>.urdf            # mimic count
+   grep -c 'type="revolute"\|type="prismatic"' robots/<robot>/<robot>.urdf
+   ```
+   `total - mimic = number of independent (controllable) joints`. The
+   converted MJCF should ultimately have that many actuators (gotcha §3).
+
+## Convert
+
+From the bundle root, with the bundle-local venv:
+
+```bash
+cd robot-assets-skills/
+./.venv/bin/python ../convert_mjcf_urdf.py \
+    "$(pwd)/robots/<robot>/<robot>.urdf" --to-mjcf
+```
+
+Output goes to `robots/<robot>/<robot>.xml` by default. Compile-check:
+
+```bash
+./.venv/bin/python -c "
+import mujoco
+m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.xml')
+print('nq=', m.nq, 'nu=', m.nu, 'nbody=', m.nbody)
+"
+```
+
+`nu = 0` is **expected** at this stage — gotcha §3 fixes that.
+
+## Post-tune (the work)
+
+Each gotcha is a discrete edit to the converted MJCF. Apply in roughly
+this order:
+
+### Fix 1: Re-add mimic relationships as `<equality>`
+
+If `mimic_count > 0` from preflight, the converted MJCF is missing
+those constraints. Add an `<equality>` block per `gotchas.md` §1 with
+one `<joint>` element per mimic relationship.
+
+After fix 1, viewer should show driving the primary joint also moves
+the mimic'd joint(s).
+
+### Fix 2: Rescale inertias
+
+Inspect each link's `<inertial>` per `gotchas.md` §2. Override the
+ones that are 100x outside reasonable values. For dex hands,
+copy from menagerie's hand-tuned inertias as reference.
+
+### Fix 3: Add actuators
+
+Add a `<default>` class with `kp`/`kv` defaults, then a `<actuator>`
+block with one `<position>` per *primary* joint (not mimics — those
+are driven via the `<equality>`). See `gotchas.md` §3 for the template.
+
+After fix 3, the viewer should show one slider per controllable joint,
+and dragging a slider should drive the joint to the target.
+
+### Fix 4: Add contact excludes for palm-knuckle pairs
+
+For dex hands: add `<contact><exclude>` entries for palm↔proximal-link
+pairs (and any other adjacent-in-rest-pose pairs). See `gotchas.md` §4.
+
+After fix 4, joints should reach their commanded targets without
+sticking partway.
+
+### Fix 5: Compiler / option attributes
+
+Add `autolimits="true"` to `<compiler>` and `<option integrator="implicitfast"/>`
+per `gotchas.md` §5.
+
+## Verify
+
+1. **Compile + count check:**
+   ```bash
+   ./.venv/bin/python -c "
+   import mujoco
+   m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.xml')
+   print('nq=', m.nq, 'nu=', m.nu)
+   for i in range(m.nu):
+       print(' ', i, m.actuator(i).name, '->', m.joint(m.actuator(i).trnid[0]).name)
+   "
+   ```
+   Expected: `nu = independent_joints` from preflight. Each actuator
+   maps to one primary joint.
+
+2. **Equality count:**
+   ```bash
+   ./.venv/bin/python -c "
+   import mujoco
+   m = mujoco.MjModel.from_xml_path('robots/<robot>/<robot>.xml')
+   print('eq:', m.neq)
+   "
+   ```
+   Expected: `neq = mimic_count` from preflight.
+
+3. **Viewer test** (must — most fix-ups are visual/dynamic, not
+   compile-time):
+   ```bash
+   DISPLAY=:5 ./.venv/bin/python -m mujoco.viewer \
+       --mjcf robots/<robot>/<robot>.xml
+   ```
+   Drive each actuator to its limits. Confirm:
+   - Primary joint reaches target.
+   - Mimic'd joints follow (visually proportional).
+   - No joint sticks partway (would indicate missing contact excludes).
+   - No numerical blowup (would indicate bad inertia or integrator).
+
+## Register
+
+Drop a `robot.json` in `robots/<robot>/`. Mjcf-only registration if
+URDF + MJCF use different mesh dirs (e.g. URDF in `meshes/`, MJCF in
+`assets/`):
+
+```json
+{
+  "robot": {
+    "name": "<owner>/<robot>",
+    "display_name": "<Robot display name>",
+    "description": "<short description>",
+    "visibility": "official",
+    "is_verified": true,
+    "is_featured": false
+  },
+  "version": {
+    "version": "1.0.0",
+    "is_stable": true,
+    "dof": <number of independent joints>,
+    "motor_type": "<motor type>",
+    "designer": "<original designer>",
+    "urdf_file": null,
+    "mjcf_file": "<robot>.xml",
+    "meshes_dir": "assets",
+    "changelog": "Initial release - hand-tuned MJCF from URDF source via urdf-to-mjcf skill. Added <equality> for N mimics, rescaled inertias, added M position actuators, palm-knuckle contact excludes, autolimits + implicitfast integrator."
+  }
+}
+```
+
+## Commit (when registering upstream)
+
+The bundle's `robots/` is gitignored. To register in the parent repo:
+
+```bash
+cp -r robots/<robot>/ ../robots/<robot>/
+cd ..
+git add robots/<robot>/
+git commit -m "Add <robot> MJCF (hand-tuned from URDF)"
+git push origin main
+```

--- a/robot-assets-skills/.claude/skills/urdf-to-mjcf/requirements.txt
+++ b/robot-assets-skills/.claude/skills/urdf-to-mjcf/requirements.txt
@@ -1,0 +1,10 @@
+# urdf-to-mjcf — runtime requirements
+#
+# MuJoCo's URDF loader is built into the `mujoco` package; the
+# `mjcf-urdf-simple-converter` shim wraps it for the script's CLI.
+# `lxml` is for the post-tune XML rewrites (adding equality blocks,
+# rescaling inertias, injecting actuators) without losing comments.
+
+mujoco>=3.5
+mjcf-urdf-simple-converter
+lxml>=4.9

--- a/robot-assets-skills/.gitignore
+++ b/robot-assets-skills/.gitignore
@@ -1,0 +1,13 @@
+# Bundle-local venv (bootstrap from AGENTS.md)
+.venv/
+
+# User-populated robot assets (copy your arm + end-effector folders here)
+robots/
+
+# Python
+__pycache__/
+*.pyc
+
+# MuJoCo
+MUJOCO_LOG.TXT
+MJMODEL.TXT

--- a/robot-assets-skills/AGENTS.md
+++ b/robot-assets-skills/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md
+
+Skill bundle for coding agents (Claude Code, Codex, etc.) working with
+robot URDF/MJCF assets — attaching end-effectors, converting between
+URDF and MJCF, and the post-processing fixups the underlying scripts
+don't handle.
+
+## Skill routing
+
+Use the bundled skills for workflow details:
+
+- `.claude/skills/attach-end-effector/SKILL.md` — mount a gripper, dex
+  hand, or tool on a robot arm via MuJoCo's MjSpec API. Use when
+  combining an arm MJCF and an end-effector MJCF into a single
+  `robots/<arm>_<eef>/` model.
+- `.claude/skills/urdf-to-mjcf/SKILL.md` — convert a URDF to MJCF and
+  post-tune the result (mimics → `<equality>`, inertias, contact
+  excludes, position actuators). Always check `mujoco_menagerie` first.
+- `.claude/skills/mjcf-to-urdf/SKILL.md` — reverse direction for
+  pinocchio/RViz/MoveIt consumers. Lossy: equality constraints,
+  actuators, contact excludes all drop. Use only when the consumer
+  doesn't accept MJCF and a hand-maintained URDF doesn't already exist.
+
+When asked to *combine* an arm and end-effector, route to
+`attach-end-effector`. When asked to *bring a URDF into MuJoCo*, route
+to `urdf-to-mjcf`. When asked to *export an MJCF for an external
+URDF-only consumer*, route to `mjcf-to-urdf`.
+
+`AGENTS.md` is intentionally bundle-focused. Reusable workflow rules
+and gotchas live inside each skill's `references/`.
+
+## Python environment
+
+Use the bundle-local venv:
+
+```bash
+./.venv/bin/python
+```
+
+Bootstrap if missing or broken:
+
+```bash
+cd robot-assets-skills/
+python3 -m venv .venv
+for s in attach-end-effector urdf-to-mjcf mjcf-to-urdf; do
+    ./.venv/bin/pip install -r .claude/skills/$s/requirements.txt
+done
+```
+
+Each skill owns its `requirements.txt`. The shared `.venv/` works for
+all three planned skills (they all need `mujoco>=3.5`); add per-skill
+deps as new skills are scaffolded. If a future skill needs deps that
+conflict with the shared venv (e.g. ROS), it should declare its own
+env in its `SKILL.md` and explicitly say "do not install into the
+shared `.venv`".
+
+## Bundle conventions
+
+- **`robots/` is user-populated.** It's gitignored. Each user copies
+  their arm folder and end-effector folder in before running the
+  skills. See `README.md` "First-time setup".
+- **Folder name == MJCF name.** `piper_arm/` contains `piper_arm.xml`.
+  Skills assume this; don't rename one without the other.
+- **`<site name="attachment_site"/>` on the arm.** Arms expose this
+  site at the wrist flange. End-effectors mount at this site via the
+  `attach-end-effector` skill.
+- **MJCF-only registration** is the convention for combined models:
+  `robot.json` with `urdf_file: null`, `mjcf_file: <name>.xml`,
+  `meshes_dir: assets`. Combined `<arm>_<eef>/` folders generally
+  don't ship a URDF.
+- **Headless display:** if running on a headless box with X on `:5`,
+  prefix viewer commands with `DISPLAY=:5`.
+
+## Source of truth
+
+- The wrapped Python scripts (e.g. `attach_arm_gripper.py`) are
+  authoritative. Skills add a workflow + gotcha layer; they don't
+  replace the script.
+- `robots/<robot>/robot.json` is the registration record. The
+  `mjcf_file` / `urdf_file` / `meshes_dir` fields drive downstream
+  consumers (S3 sync, registration db, etc.).
+- Prefer hand-tuned upstream MJCFs (e.g. `mujoco_menagerie`) over
+  running an auto-converter when an upstream MJCF exists.
+
+## Repo policies
+
+- Never commit `.venv/` or `robots/` from this bundle (both are in
+  `.gitignore`).
+- Combined `.mjb` binary caches are typically 50–80 MB; current policy
+  is to commit them when the combined model is registered as a
+  released robot, but they're not required at the bundle level.
+- Edit source files; never hand-edit generated combined models when
+  you can re-run the skill instead. (Exception: the post-attach fixups
+  documented in `gotchas.md` are *expected* hand edits.)

--- a/robot-assets-skills/CLAUDE.md
+++ b/robot-assets-skills/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+See `AGENTS.md` for the bundle's instructions and skill-routing
+guidance.
+
+`AGENTS.md` is the canonical source of truth for agent behavior in
+this skill bundle.

--- a/robot-assets-skills/README.md
+++ b/robot-assets-skills/README.md
@@ -1,0 +1,151 @@
+# robot-assets-skills
+
+Claude-Code skill bundle for working with robot URDF/MJCF assets:
+attaching end-effectors, converting between URDF and MJCF, and the
+post-processing fixups the underlying scripts don't handle.
+
+## Skills
+
+| Skill | Status | Slash command | Purpose |
+|---|---|---|---|
+| `attach-end-effector` | ready | `/attach-end-effector` | Mount a gripper / dex hand / tool on a robot arm via MuJoCo's MjSpec API. |
+| `urdf-to-mjcf` | ready | `/urdf-to-mjcf` | Convert URDF→MJCF and post-tune (mimics → `<equality>`, inertias, contact excludes, position actuators). Always check `mujoco_menagerie` first. |
+| `mjcf-to-urdf` | ready | `/mjcf-to-urdf` | Convert MJCF→URDF for pinocchio/RViz consumers. Lossy — equality, actuators, contact excludes all dropped. |
+
+See `pathonai_robot_assets/docs/SKILLS_PLAN.md` for the full plan.
+
+## Directory structure
+
+```
+robot-assets-skills/
+├── README.md                              ← this file
+├── AGENTS.md                              ← skill routing + Python env
+├── CLAUDE.md                              ← points at AGENTS.md
+├── .gitignore                             ← ignores .venv/ and robots/
+├── .venv/                                 ← bundle-local venv (bootstrap below)
+├── .claude/skills/                        ← skill definitions
+│   ├── attach-end-effector/
+│   │   ├── SKILL.md
+│   │   ├── requirements.txt
+│   │   └── references/{workflow,gotchas}.md
+│   ├── urdf-to-mjcf/
+│   │   ├── SKILL.md
+│   │   ├── requirements.txt
+│   │   └── references/{workflow,gotchas}.md
+│   └── mjcf-to-urdf/
+│       ├── SKILL.md
+│       ├── requirements.txt
+│       └── references/{workflow,gotchas}.md
+└── robots/                                ← you populate this (gitignored)
+    ├── <arm-name>/                        ← part 1: copy in your arm
+    │   ├── <arm-name>.xml                 MJCF — required, must have <site name="attachment_site"/>
+    │   ├── <arm-name>.urdf                URDF — optional, for RViz/pinocchio
+    │   ├── assets/                        STL/OBJ meshes referenced by the MJCF
+    │   └── robot.json                     registration metadata — optional
+    ├── <eef-name>/                        ← part 2: copy in your end-effector
+    │   ├── <eef-name>.xml                 MJCF — required
+    │   ├── assets/  or  meshes/           depends on the source (see gotchas §4)
+    │   └── robot.json
+    └── <arm-name>_<eef-name>/             ← part 3: created by the skill
+        ├── <arm-name>_<eef-name>.xml      combined MJCF
+        ├── <arm-name>_<eef-name>.mjb      binary cache (large)
+        ├── scene.xml                      wraps the MJCF for viewer use
+        ├── assets/                        merged meshes from arm + eef
+        ├── README.md                      generated description
+        └── robot.json                     you write this last
+```
+
+### Conventions
+
+The `attach-end-effector` skill (and the underlying script) assumes:
+
+1. **Folder name == MJCF name.** `piper_arm/` contains `piper_arm.xml`.
+2. **`<site name="attachment_site"/>` on the arm**, at the wrist
+   flange, with the site's `pos` / `quat` defining the mount frame. If
+   your arm doesn't have one, add it before invoking the skill.
+3. **`assets/` is the default mesh dir.** If your end-effector's
+   `<compiler meshdir="...">` points elsewhere (e.g. `meshes/`, or
+   unset), the skill handles the post-attach copy — see
+   `.claude/skills/attach-end-effector/references/gotchas.md` §4.
+4. **Output folder name is `<arm>_<eef>`.** Pure convention; pass it
+   via `--output`.
+
+## First-time setup
+
+Run once when you first clone or copy this bundle.
+
+### 1. Bootstrap the venv
+
+```bash
+cd robot-assets-skills/
+python3 -m venv .venv
+for s in attach-end-effector urdf-to-mjcf mjcf-to-urdf; do
+    ./.venv/bin/pip install -r .claude/skills/$s/requirements.txt
+done
+```
+
+Verify:
+```bash
+./.venv/bin/python -c 'import mujoco; print(mujoco.__version__)'
+# Expect >= 3.5
+```
+
+### 2. Populate `robots/` with your two parts
+
+Copy your arm folder and end-effector folder into `robots/`:
+
+```bash
+cp -r /path/to/your/arm     robots/<arm-name>/
+cp -r /path/to/your/eef     robots/<eef-name>/
+```
+
+Each folder must follow the structure under "Directory structure"
+above (folder name matches the `.xml` name, `assets/` directory present).
+
+Confirm both compile standalone before you attach:
+
+```bash
+./.venv/bin/python -c "
+import mujoco
+print('arm:', mujoco.MjModel.from_xml_path('robots/<arm-name>/<arm-name>.xml').nu, 'actuators')
+print('eef:', mujoco.MjModel.from_xml_path('robots/<eef-name>/<eef-name>.xml').nu, 'actuators')
+"
+```
+
+### 3. Launch Claude Code from the bundle
+
+```bash
+cd robot-assets-skills/
+claude
+```
+
+The bundle's `.claude/skills/` is auto-discovered. Verify with the
+slash-command autocomplete (type `/` and look for
+`attach-end-effector`).
+
+## Usage
+
+Once setup is done:
+
+```
+/attach-end-effector mount <eef-name> on <arm-name>
+```
+
+Or describe the task naturally — the agent reads the skill's frontmatter
+`description:` and auto-invokes when it matches. Example:
+
+> "Combine piper_arm with allegro_right into a piper_arm_allegro_right
+>  model."
+
+The skill walks through the workflow in
+`.claude/skills/attach-end-effector/references/workflow.md` and
+post-processes around the four known failure modes documented in
+`.claude/skills/attach-end-effector/references/gotchas.md`.
+
+## What the skill doesn't do
+
+- Generate the URDFs/MJCFs themselves (use `urdf-to-mjcf` when ready).
+- Verify the *physical* correctness of the combined model (inertias,
+  joint limits, friction). The skill flags only the *kinematic* and
+  *asset-bookkeeping* issues that compile-cleanly-but-look-wrong.
+- Drive simulation. It produces the model; you bring the controller.


### PR DESCRIPTION
## Summary
- Adds `robot-assets-skills/` — an `AGENTS.md`-pattern skill bundle for Claude Code / Codex when working on robot MJCF/URDF assets. Cloned alongside an asset repo, it provides routing instructions and concrete skill recipes.
- Ships the `attach-end-effector` skill: wraps `attach_arm_gripper.py` (MuJoCo `MjSpec` attach) with a preflight checklist and post-script fixes for the four known silent-failure modes — mesh-filename collisions, palm-origin offsets for menagerie hands, empty-prefix failures (entity collisions and bare nested `<default>` blocks), and the script's `<compiler meshdir>` blind spot when the gripper doesn't ship its meshes under `assets/`.
- Stubs `urdf-to-mjcf` and `mjcf-to-urdf` skills as placeholders for future MJCF/URDF interop work.

## Test plan
- [ ] `cd robot-assets-skills/` from a fresh clone and follow `README.md`'s first-time-setup steps; confirm `.venv/` bootstraps and `robots/` accepts user-copied arm + eef dirs.
- [ ] In Claude Code from this dir, confirm `/attach-end-effector` is listed and routes correctly per `AGENTS.md`.
- [ ] Run `attach-end-effector` end-to-end on a known pair (e.g. `piper_arm` + `barrett_hand`) and verify the four post-script checks (gripper-mesh copy, collision sizes, flange-mount visual, actuator slider mapping) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)